### PR TITLE
Delete search changes

### DIFF
--- a/src/protocols/Protocols.Administration/Controllers/SubjectsController .cs
+++ b/src/protocols/Protocols.Administration/Controllers/SubjectsController .cs
@@ -21,6 +21,12 @@ namespace Protocols.Administration.Controllers
             return Repository.GetAll().ToList();
 		}
 
+		[AllowCrossSiteJsonAttribute]
+		public Subject Get(Guid id)
+		{
+			return Repository.FindBy(id);
+		}
+
 		[HttpPost]
 		[AllowCrossSiteJsonAttribute]
 		public Guid Post(Subject subject)

--- a/src/protocols/Protocols.Repository/IRepository.cs
+++ b/src/protocols/Protocols.Repository/IRepository.cs
@@ -11,10 +11,7 @@ namespace Protocols.Repository
 		Guid Insert(T entry);
 		void Remove(Guid id);
         void Remove(T entry);
-
-
-		//Still thinking what to do with this, doesnt belong here, so far.
-		//T FindBy(Guid id); 
+		T FindBy(Guid id); 
     }
 
 }

--- a/src/protocols/Protocols.Repository/SubjectRepository.cs
+++ b/src/protocols/Protocols.Repository/SubjectRepository.cs
@@ -44,13 +44,11 @@ namespace Protocols.Repository
 			this.Remove (entry.Id);
         }
 
-        public Subject FindBy(string name)
+        public Subject FindBy(Guid id)
         {
-//            return this._collection.AsQueryable().Where(
-//				sbj => sbj.Id == id
-//			).FirstOrDefault();
-
-			throw new NotImplementedException ("Not done yet");
+            return this._collection.AsQueryable().Where(
+				sbj => sbj.Id == id
+			).FirstOrDefault();
         }
     }
 }


### PR DESCRIPTION
- Do not return strings in Controller methods, for now. The logic for the return statuses, should be defined later. For now we'll keep returning and using whatever the Repository return.
- Good idea about the IDGenerator
-  Methods in the Repository Pattern should be related to the Model, not to the Database implementation. Like return WriteConcernResult, not good.
- Be consistent with naming, if the parent interface used 'id' as a reference to the key, do not change the name of the parameter in the subclass. 'subject_id'
- In the remove method of the controller you had:
  var to_delete = Repository.FindById(subject);
  var result = Repository.Remove(to_delete);

This is wrong, you're doing one extra query out of nothing. Just removeBy id in the Repository, and use the id you've gotten from the Controller. 

@MichaelMtz ,@ajadex FYI
